### PR TITLE
Add cattle-prometheus namespace

### DIFF
--- a/rancher_logs_collector.sh
+++ b/rancher_logs_collector.sh
@@ -91,7 +91,7 @@ done
 # System pods
 mkdir -p $TMPDIR/k8s/podlogs
 mkdir -p $TMPDIR/k8s/podinspect
-SYSTEMNAMESPACES=(kube-system kube-public cattle-system cattle-alerting cattle-logging cattle-pipeline ingress-nginx)
+SYSTEMNAMESPACES=(kube-system kube-public cattle-system cattle-alerting cattle-logging cattle-pipeline ingress-nginx cattle-prometheus)
 for SYSTEMNAMESPACE in "${SYSTEMNAMESPACES[@]}"; do
   CONTAINERS=$(docker ps -a --filter name=$SYSTEMNAMESPACE --format "{{.Names}}")
   for CONTAINER in $CONTAINERS; do


### PR DESCRIPTION
Add cattle-prometheus namespace to list of SYSTEMNAMESPACES for which to generate `docker inspect` and `docker logs` output