### PR TITLE
Added change output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ The script needs to be downloaded and run directly on the host using the `root` 
 * Download the script and save as: `rancher_logs_collector.sh`
 * Make sure the script is executable: `chmod +x rancher_logs_collector.sh`
 * Run the script: `./rancher_logs_collector.sh`
+
+### To change the default output directory, please use one of the following.
+* `DIR="/mnt/data/logs/" ./rancher_logs_collector.sh`
+* `./rancher_logs_collector.sh --dir "/mnt/data/logs/"`

--- a/rancher_logs_collector.sh
+++ b/rancher_logs_collector.sh
@@ -1,7 +1,37 @@
 #!/bin/bash
 
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -d|--dir)
+    DIR="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    *)    # unknown option
+    POSITIONAL+=("$1") # save it in an array for later
+    shift # past argument
+    ;;
+esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
 # Create temp directory
-TMPDIR=$(mktemp -d)
+if [[ -z $DIR ]]
+then
+	# Use /tmp by default
+	TMPDIR=$(mktemp -d)
+else
+	# Use command line argument instead of /tmp
+	mkdir -p "$DIR"
+	TMPDIR=$(mktemp -d --tmpdir="$DIR")
+fi
+
+echo $TMPDIR
+exit 0
 
 # System info
 mkdir -p $TMPDIR/systeminfo


### PR DESCRIPTION
This will allow you to change the output directory from /tmp to a custom.

This option is useful if you don't have a lot of free space and want to dump the logs to a NFS share instead.

Signed-off-by: Matthew Mattox <cube8021@gmail.com>